### PR TITLE
Step 5

### DIFF
--- a/5_macro_definitions.ql
+++ b/5_macro_definitions.ql
@@ -1,2 +1,5 @@
+import cpp
 
-
+from Macro m
+where m.getName().regexpMatch("ntoh(s|l|ll)")
+select m


### PR DESCRIPTION
Step 5 finds all macros named 'ntohs' or 'ntohl' or 'ntohll'. 